### PR TITLE
fix: wallet name not updating after replacement; modal opening repeatedly

### DIFF
--- a/packages/hooks/hooks-ca/wallet.ts
+++ b/packages/hooks/hooks-ca/wallet.ts
@@ -79,6 +79,16 @@ export const useCurrentUserInfo = (forceUpdate?: boolean) => {
   return userInfo?.[currentNetwork] || DEFAULT_USER_INFO;
 };
 
+export const useRefreshUserInfo = () => {
+  const dispatch = useAppCommonDispatch();
+
+  const refreshUserInfo = useCallback(() => {
+    dispatch(getCaHolderInfoAsync());
+  }, [dispatch]);
+
+  return refreshUserInfo;
+};
+
 export const useCurrentWalletInfo = () => {
   const { currentNetwork, walletInfo } = useWallet();
   const originChainId = useOriginChainId();
@@ -330,11 +340,12 @@ export const useSetNewWalletName = () => {
   const caHash = useCurrentCaHash();
   const originChainId = useOriginChainId();
   const { shouldShowSetNewWalletNameModal, shouldShowSetNewWalletNameIcon } = useCurrentUserInfo();
+  const refreshUserInfo = useRefreshUserInfo();
 
-  const updateShouldData = useCallback(() => {
+  const updateShouldData = useCallback(async () => {
     try {
-      dispatch(fetchShouldShowSetNewWalletNameModal());
-      dispatch(fetchShouldShowSetNewWalletNameIcon());
+      await dispatch(fetchShouldShowSetNewWalletNameModal());
+      await dispatch(fetchShouldShowSetNewWalletNameIcon());
     } catch (error) {
       console.error('Failed to update shouldShow data:', error);
     }
@@ -347,13 +358,14 @@ export const useSetNewWalletName = () => {
   const handleSetNewWalletName = useCallback(async () => {
     if (!caHash || !originChainId) throw new Error('Missing caHash or chainId');
     await dispatch(setNewWalletName({ caHash, chainId: originChainId }));
-    updateShouldData();
-  }, [caHash, dispatch, originChainId, updateShouldData]);
+    await updateShouldData();
+    await refreshUserInfo();
+  }, [caHash, dispatch, originChainId, updateShouldData, refreshUserInfo]);
 
   const handleCancelSetNewWalletNameModal = useCallback(async () => {
     if (!caHash || !originChainId) throw new Error('Missing caHash or chainId');
     await dispatch(cancelSetNewWalletNameModal({ caHash, chainId: originChainId }));
-    updateShouldData();
+    await updateShouldData();
   }, [caHash, dispatch, originChainId, updateShouldData]);
 
   return useMemo(

--- a/packages/web-extension-did/app/web/pages/Home/components/SetNewWalletNameIcon/index.tsx
+++ b/packages/web-extension-did/app/web/pages/Home/components/SetNewWalletNameIcon/index.tsx
@@ -11,12 +11,12 @@ export default function SetNewWalletNameIcon() {
   const { shouldShowSetNewWalletNameIcon, handleSetNewWalletName } = useSetNewWalletName();
   const [isOpen, setIsOpen] = useState(false);
 
-  const handlePopoverConfirm = useCallback(() => {
-    setIsOpen(false);
-    handleSetNewWalletName().catch((error) => {
+  const handlePopoverConfirm = useCallback(async () => {
+    await handleSetNewWalletName().catch((error) => {
       const msg = handleErrorMessage(error);
       singleMessage.error(msg);
     });
+    setIsOpen(false);
   }, [handleSetNewWalletName]);
 
   const popoverContent = useMemo(() => {

--- a/packages/web-extension-did/app/web/pages/Home/components/SetNewWalletNameModal/index.tsx
+++ b/packages/web-extension-did/app/web/pages/Home/components/SetNewWalletNameModal/index.tsx
@@ -19,16 +19,16 @@ export default function SetNewWalletNameModal() {
     }
   }, [shouldShowSetNewWalletNameModal]);
 
-  const handleConfirm = () => {
-    handleSetNewWalletName().catch((error) => {
+  const handleConfirm = async () => {
+    await handleSetNewWalletName().catch((error) => {
       const msg = handleErrorMessage(error);
       singleMessage.error(msg);
     });
     setIsOpen(false);
   };
 
-  const handleCancel = () => {
-    handleCancelSetNewWalletNameModal().catch((error) => {
+  const handleCancel = async () => {
+    await handleCancelSetNewWalletNameModal().catch((error) => {
       const msg = handleErrorMessage(error);
       singleMessage.error(msg);
     });


### PR DESCRIPTION
1. fix: wallet name not updating after replacement; modal opening repeatedly