### PR TITLE
refactor: ♻️ deprecate ETransfer, use eBridge for all cross-chain tra…

### DIFF
--- a/packages/web-extension-aelf/app/web/hooks/etransfer.ts
+++ b/packages/web-extension-aelf/app/web/hooks/etransfer.ts
@@ -1,27 +1,39 @@
-import { useCurrentNetworkInfo } from '@portkey-wallet/hooks/hooks-eoa/network';
-import { useCurrentAccount } from '@portkey-wallet/hooks/hooks-eoa/wallet';
-import { useCallback, useEffect } from 'react';
-import { eTransferCore } from '@etransfer/core';
-import { useCommonState } from 'store/Provider/hooks';
-import { useLatestRef } from '@portkey-wallet/hooks';
-import { sleep } from '@portkey-wallet/utils';
+/**
+ * [DEPRECATED-ETRANSFER] - This entire file is deprecated.
+ * ETransfer registration check has been removed in favor of eBridge for all cross-chain transfers.
+ * Keeping this file for reference and potential future restoration.
+ */
 
-export const useCheckETransferIsRegistration = (noRegistrationCallback: () => void) => {
-  const { isPrompt } = useCommonState();
-  const latestIsPrompt = useLatestRef(isPrompt);
-  const { eTransferUrl } = useCurrentNetworkInfo();
-  const account = useCurrentAccount();
-  const checkIsRegistration = useCallback(async () => {
-    await sleep(100);
-    if (!account?.address || latestIsPrompt.current) return;
-    eTransferCore.init({
-      etransferUrl: eTransferUrl,
-    });
-    const isRegistration = await eTransferCore.services.checkEOARegistration({ address: account?.address });
-    if (!isRegistration.result) return noRegistrationCallback();
-  }, [account?.address, eTransferUrl, latestIsPrompt, noRegistrationCallback]);
+// import { useCurrentNetworkInfo } from '@portkey-wallet/hooks/hooks-eoa/network';
+// import { useCurrentAccount } from '@portkey-wallet/hooks/hooks-eoa/wallet';
+// import { useCallback, useEffect } from 'react';
+// import { eTransferCore } from '@etransfer/core';
+// import { useCommonState } from 'store/Provider/hooks';
+// import { useLatestRef } from '@portkey-wallet/hooks';
+// import { sleep } from '@portkey-wallet/utils';
 
-  useEffect(() => {
-    checkIsRegistration();
-  }, [checkIsRegistration]);
+/**
+ * @deprecated ETransfer registration check is no longer needed. Use eBridge instead.
+ */
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+export const useCheckETransferIsRegistration = (_noRegistrationCallback: () => void) => {
+  // [DEPRECATED-ETRANSFER] BEGIN - ETransfer registration check disabled
+  // const { isPrompt } = useCommonState();
+  // const latestIsPrompt = useLatestRef(isPrompt);
+  // const { eTransferUrl } = useCurrentNetworkInfo();
+  // const account = useCurrentAccount();
+  // const checkIsRegistration = useCallback(async () => {
+  //   await sleep(100);
+  //   if (!account?.address || latestIsPrompt.current) return;
+  //   eTransferCore.init({
+  //     etransferUrl: eTransferUrl,
+  //   });
+  //   const isRegistration = await eTransferCore.services.checkEOARegistration({ address: account?.address });
+  //   if (!isRegistration.result) return noRegistrationCallback();
+  // }, [account?.address, eTransferUrl, latestIsPrompt, noRegistrationCallback]);
+  // useEffect(() => {
+  //   checkIsRegistration();
+  // }, [checkIsRegistration]);
+  // [DEPRECATED-ETRANSFER] END
+  // No-op: ETransfer registration check is deprecated
 };

--- a/packages/web-extension-aelf/app/web/hooks/useCrossTransferByEtransfer.ts
+++ b/packages/web-extension-aelf/app/web/hooks/useCrossTransferByEtransfer.ts
@@ -1,13 +1,20 @@
+/**
+ * [DEPRECATED-ETRANSFER] - This entire file is deprecated.
+ * ETransfer logic has been removed in favor of eBridge for all cross-chain transfers.
+ * Keeping this file for reference and potential future restoration.
+ */
+
 import { useEffect, useMemo } from 'react';
-import { CrossTransferExtension } from 'utils/sandboxUtil/extension-cross-chain';
+// import { CrossTransferExtension } from 'utils/sandboxUtil/extension-cross-chain';
 import { usePin } from './usePin';
 import { useCurrentNetworkInfo } from '@portkey-wallet/hooks/hooks-eoa/network';
 import { useCurrentChainList } from '@portkey-wallet/hooks/hooks-eoa/chainList';
-import { localStorage } from 'redux-persist-webextension-storage';
+// import { localStorage } from 'redux-persist-webextension-storage';
 import { useCurrentAccount } from '@portkey-wallet/hooks/hooks-eoa/wallet';
 import { reCAPTCHAActionETransfer } from 'utils/lib/serviceWorkerAction';
 
-const crossChainTransfer = new CrossTransferExtension();
+// [DEPRECATED-ETRANSFER] CrossTransferExtension instance removed
+// const crossChainTransfer = new CrossTransferExtension();
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 export const verifyHumanMachine = async (_language: any, _isEtransfer = false, isMainnet?: boolean) => {
@@ -15,6 +22,9 @@ export const verifyHumanMachine = async (_language: any, _isEtransfer = false, i
   return req.response;
 };
 
+/**
+ * @deprecated Use eBridge for cross-chain transfers instead
+ */
 export const useCrossTransferByEtransfer = () => {
   const pin = usePin();
   const account = useCurrentAccount();
@@ -22,22 +32,29 @@ export const useCrossTransferByEtransfer = () => {
   const currentChainList = useCurrentChainList();
 
   useEffect(() => {
-    if (!eTransferUrl || !pin || !currentChainList || !eTransferCA || !account) return;
-    crossChainTransfer.init({
-      account,
-      eTransferUrl: eTransferUrl,
-      pin,
-      chainList: currentChainList,
-      eTransferCA,
-      storage: localStorage,
-      verifyHumanMachine: verifyHumanMachine,
-    });
+    // [DEPRECATED-ETRANSFER] ETransfer initialization disabled
+    // if (!eTransferUrl || !pin || !currentChainList || !eTransferCA || !account) return;
+    // crossChainTransfer.init({
+    //   account,
+    //   eTransferUrl: eTransferUrl,
+    //   pin,
+    //   chainList: currentChainList,
+    //   eTransferCA,
+    //   storage: localStorage,
+    //   verifyHumanMachine: verifyHumanMachine,
+    // });
+    console.warn('[DEPRECATED] useCrossTransferByEtransfer is deprecated. Use eBridge instead.');
   }, [account, currentChainList, eTransferCA, eTransferUrl, pin]);
 
   return useMemo(
     () => ({
-      withdraw: crossChainTransfer.withdraw,
-      withdrawPreview: crossChainTransfer.withdrawPreview,
+      // [DEPRECATED-ETRANSFER] Return no-op functions
+      withdraw: async () => {
+        throw new Error('[DEPRECATED] ETransfer withdraw is disabled. Use eBridge instead.');
+      },
+      withdrawPreview: async () => {
+        throw new Error('[DEPRECATED] ETransfer withdrawPreview is disabled. Use eBridge instead.');
+      },
     }),
     [],
   );

--- a/packages/web-extension-aelf/app/web/messages/SandboxEventTypes.ts
+++ b/packages/web-extension-aelf/app/web/messages/SandboxEventTypes.ts
@@ -10,8 +10,8 @@ enum SandboxEventTypes {
   getTransactionRaw = 'getTransactionRaw',
 
   initViewContract = 'initViewContract',
-  // cross etransfer
-  etransferCrossTransfer = 'etransferCrossTransfer',
+  // [DEPRECATED-ETRANSFER] cross etransfer - deprecated, use eBridge instead
+  // etransferCrossTransfer = 'etransferCrossTransfer',
   // cross eBridge
   eBridgeCrossTransfer = 'eBridgeCrossTransfer',
   eBridgeCrossTransferLimit = 'eBridgeCrossTransferLimit',

--- a/packages/web-extension-aelf/app/web/pages/Example/index.tsx
+++ b/packages/web-extension-aelf/app/web/pages/Example/index.tsx
@@ -2,7 +2,9 @@ import { addDapp, removeDapp } from '@portkey-wallet/store/store-ca/dapp/actions
 import { useNavigate } from 'react-router-dom';
 // import { SocialLoginEnum } from '@portkey-wallet/types/types-ca/wallet';
 import { Button } from 'antd';
-import { useCrossTransferByEtransfer } from 'hooks/useCrossTransferByEtransfer';
+// [DEPRECATED-ETRANSFER] BEGIN - useCrossTransferByEtransfer import deprecated
+// import { useCrossTransferByEtransfer } from 'hooks/useCrossTransferByEtransfer';
+// [DEPRECATED-ETRANSFER] END
 import { useAppDispatch } from 'store/Provider/hooks';
 import { setCountryModal } from 'store/reducers/modal/slice';
 // import googleAnalytics from 'utils/googleAnalytics';
@@ -12,7 +14,9 @@ import { useBackupWalletModal } from 'hooks/wallet/useBackupWalletModal';
 
 export default function Example() {
   const dispatch = useAppDispatch();
-  const { withdraw, withdrawPreview } = useCrossTransferByEtransfer();
+  // [DEPRECATED-ETRANSFER] BEGIN - ETransfer hook usage deprecated
+  // const { withdraw, withdrawPreview } = useCrossTransferByEtransfer();
+  // [DEPRECATED-ETRANSFER] END
   const { showBackupWalletModal } = useBackupWalletModal();
   const navigate = useNavigate();
 
@@ -123,7 +127,8 @@ export default function Example() {
           }}>
           setPinAction
         </Button>
-        <Button
+        {/* [DEPRECATED-ETRANSFER] BEGIN - ETransfer withdraw test button deprecated */}
+        {/* <Button
           onClick={async () => {
             const withdrawPreviewResult = await withdrawPreview({
               chainId: 'tDVW',
@@ -150,7 +155,8 @@ export default function Example() {
             console.log(result, 'result==withdraw');
           }}>
           withdraw
-        </Button>
+        </Button> */}
+        {/* [DEPRECATED-ETRANSFER] END */}
       </div>
     </div>
   );

--- a/packages/web-extension-aelf/app/web/pages/Home/components/MyBalance/index.tsx
+++ b/packages/web-extension-aelf/app/web/pages/Home/components/MyBalance/index.tsx
@@ -7,8 +7,11 @@ import TokenList from '../Tokens';
 // import Activity from '../Activity/index';
 import { Transaction } from '@portkey-wallet/types/types-ca/trade';
 import NFT from '../NFT/NFT';
-import { useAppDispatch, useUserInfo, useCommonState, useLoading } from 'store/Provider/hooks';
-import { useOriginChainId } from '@portkey-wallet/hooks/hooks-ca/wallet';
+import { useAppDispatch, useUserInfo, useCommonState } from 'store/Provider/hooks';
+// [DEPRECATED-ETRANSFER] useLoading was used by handleCheckSecurity
+// import { useLoading } from 'store/Provider/hooks';
+// [DEPRECATED-ETRANSFER] useOriginChainId was used by handleCheckSecurity
+// import { useOriginChainId } from '@portkey-wallet/hooks/hooks-ca/wallet';
 // import { getSymbolImagesAsync } from '@portkey-wallet/store/store-eoa/tokenManagement/action';
 import { getCaHolderInfoAsync } from '@portkey-wallet/store/store-ca/wallet/actions';
 import CustomTokenModal from 'pages/components/CustomTokenModal';
@@ -16,11 +19,14 @@ import { IAssetItemType } from '@portkey-wallet/store/store-eoa/assets/type';
 import { useFreshTokenPrice } from '@portkey-wallet/hooks/hooks-eoa/useTokensPrice';
 import useVerifierList from 'hooks/useVerifierList';
 import { BalanceTab } from '@portkey-wallet/constants/constants-eoa/assets';
-import { useCurrentNetworkInfo } from '@portkey-wallet/hooks/hooks-eoa/network';
+// [DEPRECATED-ETRANSFER] useCurrentNetworkInfo was used for eTransferUrl
+// import { useCurrentNetworkInfo } from '@portkey-wallet/hooks/hooks-eoa/network';
 import { useUnreadCount } from '@portkey-wallet/hooks/hooks-ca/im';
 import { fetchContactListV2Async } from '@portkey-wallet/store/store-ca/contact/actions';
-import { useCheckSecurity } from 'hooks/useSecurity';
-import { useDisclaimer } from '@portkey-wallet/hooks/hooks-ca/disclaimer';
+// [DEPRECATED-ETRANSFER] BEGIN - imports used by handleClickTrade for ETransfer
+// import { useCheckSecurity } from 'hooks/useSecurity';
+// import { useDisclaimer } from '@portkey-wallet/hooks/hooks-ca/disclaimer';
+// [DEPRECATED-ETRANSFER] END
 import { useExtensionETransShow } from 'hooks/cms';
 import DisclaimerModal, { IDisclaimerProps, initDisclaimerData } from '../../../components/DisclaimerModal';
 import './index.less';
@@ -35,7 +41,8 @@ import { clsx } from 'clsx';
 import { useAccountBalanceUSD } from '@portkey-wallet/hooks/hooks-eoa/assets';
 import { formatAmountUSDShow } from '@portkey-wallet/utils/converter';
 import { RampType } from '@portkey-wallet/ramp';
-import { getDisclaimerData } from 'utils/disclaimer';
+// [DEPRECATED-ETRANSFER] getDisclaimerData was used by handleClickTrade
+// import { getDisclaimerData } from 'utils/disclaimer';
 import { TradeTypeEnum } from 'constants/trade';
 import { CustomSvgV3 } from 'components/CustomSvgV3';
 // import SetNewWalletNameIcon from '../SetNewWalletNameIcon';
@@ -79,9 +86,12 @@ export default function MyBalance() {
   const { passwordSeed } = useUserInfo();
   const appDispatch = useAppDispatch();
   const isMainNet = useIsMainnet();
-  const { eTransferUrl = '' } = useCurrentNetworkInfo();
+  // [DEPRECATED-ETRANSFER] BEGIN - eTransferUrl deprecated
+  // const { eTransferUrl = '' } = useCurrentNetworkInfo();
+  // [DEPRECATED-ETRANSFER] END
   const isFCMEnable = useFCMEnable();
-  const { setLoading } = useLoading();
+  // [DEPRECATED-ETRANSFER] setLoading was used by handleCheckSecurity
+  // const { setLoading } = useLoading();
   const setHideAssets = useSetHideAssets();
   const hideAssets = useCurrentHideAssetsState();
 
@@ -155,9 +165,11 @@ export default function MyBalance() {
   const [disclaimerOpen, setDisclaimerOpen] = useState<boolean>(false);
   const disclaimerData = useRef<IDisclaimerProps>(initDisclaimerData);
   const unreadCount = useUnreadCount();
-  const checkSecurity = useCheckSecurity();
-  const originChainId = useOriginChainId();
-  const { checkDappIsConfirmed } = useDisclaimer();
+  // [DEPRECATED-ETRANSFER] BEGIN - these were used by handleClickTrade for ETransfer
+  // const checkSecurity = useCheckSecurity();
+  // const originChainId = useOriginChainId();
+  // const { checkDappIsConfirmed } = useDisclaimer();
+  // [DEPRECATED-ETRANSFER] END
   const { isETransShow } = useExtensionETransShow();
   const reportFCMStatus = useReportFCMStatus();
   const userInfo = useCurrentAccount();
@@ -250,42 +262,44 @@ export default function MyBalance() {
     signalrFCM.signalr && setBadge({ value: unreadCount });
   }, [isFCMEnable, reportFCMStatus, unreadCount]);
 
-  const handleCheckSecurity = useCallback(async () => {
-    try {
-      setLoading(true);
-      const isSafe = await checkSecurity(originChainId);
-      setLoading(false);
-      return isSafe;
-    } catch (error) {
-      setLoading(false);
-      console.log('===handleCheckSecurity error', error);
-      return false;
-    }
-  }, [checkSecurity, originChainId, setLoading]);
+  // [DEPRECATED-ETRANSFER] BEGIN - handleCheckSecurity was used by handleClickTrade
+  // const handleCheckSecurity = useCallback(async () => {
+  //   try {
+  //     setLoading(true);
+  //     const isSafe = await checkSecurity(originChainId);
+  //     setLoading(false);
+  //     return isSafe;
+  //   } catch (error) {
+  //     setLoading(false);
+  //     console.log('===handleCheckSecurity error', error);
+  //     return false;
+  //   }
+  // }, [checkSecurity, originChainId, setLoading]);
 
-  const handleClickTrade = useCallback(
-    async (type: TradeTypeEnum) => {
-      const isSecurity = await handleCheckSecurity();
-      if (!isSecurity) return;
-
-      let tradeLink = '';
-      switch (type) {
-        case TradeTypeEnum.ETrans:
-          tradeLink = eTransferUrl;
-          break;
-      }
-      if (checkDappIsConfirmed(tradeLink)) {
-        const openWinder = window.open(tradeLink, '_blank');
-        if (openWinder) {
-          openWinder.opener = null;
-        }
-      } else {
-        disclaimerData.current = getDisclaimerData({ targetUrl: tradeLink, originUrl: tradeLink, type });
-        setDisclaimerOpen(true);
-      }
-    },
-    [checkDappIsConfirmed, eTransferUrl, handleCheckSecurity],
-  );
+  // handleClickTrade was used for ETransfer, now deprecated
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  const handleClickTrade = useCallback(async (_type: TradeTypeEnum) => {
+    console.warn('[DEPRECATED] ETransfer trade is deprecated');
+    // Original implementation:
+    // const isSecurity = await handleCheckSecurity();
+    // if (!isSecurity) return;
+    // let tradeLink = '';
+    // switch (type) {
+    //   case TradeTypeEnum.ETrans:
+    //     tradeLink = eTransferUrl;
+    //     break;
+    // }
+    // if (checkDappIsConfirmed(tradeLink)) {
+    //   const openWinder = window.open(tradeLink, '_blank');
+    //   if (openWinder) {
+    //     openWinder.opener = null;
+    //   }
+    // } else {
+    //   disclaimerData.current = getDisclaimerData({ targetUrl: tradeLink, originUrl: tradeLink, type });
+    //   setDisclaimerOpen(true);
+    // }
+  }, []);
+  // [DEPRECATED-ETRANSFER] END
 
   const handleClickBuy = useCallback(() => {
     if (!isRampShow) return;

--- a/packages/web-extension-aelf/app/web/pages/Receive/ReceiveCardPage/index.tsx
+++ b/packages/web-extension-aelf/app/web/pages/Receive/ReceiveCardPage/index.tsx
@@ -7,7 +7,10 @@ import {
   singleMessage,
 } from '@portkey/did-ui-react';
 import { useLocationState } from 'hooks/router';
-import { useReceive, useReceiveByETransfer } from '@portkey-wallet/hooks/hooks-eoa/receive';
+// [DEPRECATED-ETRANSFER] BEGIN - useReceiveByETransfer import deprecated
+import { useReceive } from '@portkey-wallet/hooks/hooks-eoa/receive';
+// import { useReceiveByETransfer } from '@portkey-wallet/hooks/hooks-eoa/receive';
+// [DEPRECATED-ETRANSFER] END
 import { MAIN_CHAIN_ID } from '@portkey-wallet/constants/constants-eoa/activity';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useNavigate } from 'react-router';
@@ -21,15 +24,18 @@ import { ReceiveType, TReceiveFromNetworkItem } from '@portkey-wallet/types/type
 import { TDepositInfo } from '@portkey-wallet/types/types-eoa/deposit';
 import { useCurrentAccount } from '@portkey-wallet/hooks/hooks-eoa/wallet';
 import { IChainItemType } from '@portkey-wallet/types/types-eoa/chain';
-import { verifyHumanMachine } from 'hooks/useCrossTransferByEtransfer';
+// [DEPRECATED-ETRANSFER] verifyHumanMachine import deprecated
+// import { verifyHumanMachine } from 'hooks/useCrossTransferByEtransfer';
 import { usePin } from 'hooks/usePin';
 import aes from '@portkey-wallet/utils/aes';
 import { useCurrentChainList } from '@portkey-wallet/hooks/hooks-eoa/chainList';
 import { SEND_RECEIVE_HELP_URL } from '@portkey-wallet/constants/constants-eoa/send';
 import FairyVaultLogo from '../../../assets/svgIcon/FairyVaultLogo.svg';
-import InternalMessage from 'messages/InternalMessage';
-import { PortkeyMessageTypes } from 'messages/InternalMessageTypes';
-import { useCheckETransferIsRegistration } from 'hooks/etransfer';
+// [DEPRECATED-ETRANSFER] BEGIN - imports used by ETransfer registration check removed
+// import InternalMessage from 'messages/InternalMessage';
+// import { PortkeyMessageTypes } from 'messages/InternalMessageTypes';
+// import { useCheckETransferIsRegistration } from 'hooks/etransfer';
+// [DEPRECATED-ETRANSFER] END
 import { usePrevious } from 'react-use';
 
 const CA_INFO = {
@@ -149,21 +155,28 @@ export default function ReceiveCardMain() {
     const pk = aes.decrypt(account.AESEncryptPrivateKey, pin);
     if (pk) return aelf.getWallet(pk);
   }, [account, pin]);
-  const { loading: _eTransferLoading, getDepositInfo } = useReceiveByETransfer({
-    manager,
-    toChainId: destinationChain?.chainId as ChainId,
-    toSymbol: selectToken.symbol,
-    fromNetwork: selectedSource?.network || '',
-    fromSymbol: selectToken.symbol,
-    verifyHumanMachine,
-  });
+  // [DEPRECATED-ETRANSFER] BEGIN - useReceiveByETransfer hook disabled
+  // const { loading: _eTransferLoading, getDepositInfo } = useReceiveByETransfer({
+  //   manager,
+  //   toChainId: destinationChain?.chainId as ChainId,
+  //   toSymbol: selectToken.symbol,
+  //   fromNetwork: selectedSource?.network || '',
+  //   fromSymbol: selectToken.symbol,
+  //   verifyHumanMachine,
+  // });
+  const _eTransferLoading = false;
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  const getDepositInfo = async () => null;
+  // [DEPRECATED-ETRANSFER] END
   const isMainnet = useIsMainnet();
 
-  useCheckETransferIsRegistration(
-    useCallback(() => {
-      InternalMessage.payload(PortkeyMessageTypes.RECEIVE_CARD, JSON.stringify(selectToken)).send();
-    }, [selectToken]),
-  );
+  // [DEPRECATED-ETRANSFER] BEGIN - useCheckETransferIsRegistration disabled
+  // useCheckETransferIsRegistration(
+  //   useCallback(() => {
+  //     InternalMessage.payload(PortkeyMessageTypes.RECEIVE_CARD, JSON.stringify(selectToken)).send();
+  //   }, [selectToken]),
+  // );
+  // [DEPRECATED-ETRANSFER] END
 
   const onGetDepositInfo = useCallback(async () => {
     const info = await getDepositInfo();
@@ -175,7 +188,8 @@ export default function ReceiveCardMain() {
   }, [getDepositInfo, previousSourceChain, setSourceChain]);
 
   useEffect(() => {
-    if (receiveType === ReceiveType.ETransfer && !currentDepositInfo) onGetDepositInfo();
+    // [DEPRECATED-ETRANSFER] ETransfer receive type disabled
+    // if (receiveType === ReceiveType.ETransfer && !currentDepositInfo) onGetDepositInfo();
   }, [currentDepositInfo, onGetDepositInfo, receiveType]);
 
   const { address } = account || { address: '' };

--- a/packages/web-extension-aelf/app/web/pages/Send/components/SendPreview/index.tsx
+++ b/packages/web-extension-aelf/app/web/pages/Send/components/SendPreview/index.tsx
@@ -79,20 +79,22 @@ export default function SendPreview({
   const EstimateAmount = useMemo(() => {
     let _amount = amount;
 
-    // adjust etransfer
-    if (
-      ZERO.plus(amount).isLessThanOrEqualTo(transactionFee || '') &&
-      tokenInfo?.symbol === 'ELF' &&
-      transferType === TransferType.E_TRANSFER
-    ) {
-      return {
-        estimateAmount: `0 ${tokenInfo?.label || tokenInfo?.symbol}`,
-        estimateAmountUsd: isMainnet ? '$0' : '',
-      };
-    }
+    // [DEPRECATED-ETRANSFER] BEGIN - E_TRANSFER check removed
+    // // adjust etransfer
+    // if (
+    //   ZERO.plus(amount).isLessThanOrEqualTo(transactionFee || '') &&
+    //   tokenInfo?.symbol === 'ELF' &&
+    //   transferType === TransferType.E_TRANSFER
+    // ) {
+    //   return {
+    //     estimateAmount: `0 ${tokenInfo?.label || tokenInfo?.symbol}`,
+    //     estimateAmountUsd: isMainnet ? '$0' : '',
+    //   };
+    // }
+    // [DEPRECATED-ETRANSFER] END
 
-    // adjust etransfer & ebridge
-    if (transferType === TransferType.E_BRIDGE || transferType === TransferType.E_TRANSFER) {
+    // adjust ebridge (E_TRANSFER removed)
+    if (transferType === TransferType.E_BRIDGE) {
       return {
         estimateAmount: `${receiveAmount} ${tokenInfo?.label || tokenInfo?.symbol}`,
         estimateAmountUsd: isMainnet ? receiveAmountUsd : '',
@@ -174,7 +176,7 @@ export default function SendPreview({
       feeUsdShow: '',
     };
     switch (transferType) {
-      case TransferType.E_TRANSFER:
+      // [DEPRECATED-ETRANSFER] E_TRANSFER case removed
       case TransferType.E_BRIDGE:
         result.feeShow = `${transactionFee} ${transactionUnit}`;
         result.feeUsdShow = `$${unitConverter(
@@ -265,12 +267,10 @@ export default function SendPreview({
           <div className="value-show">{`~${estimatedTime}`}</div>
         </div>
       )}
-      {(transferType === TransferType.E_BRIDGE || transferType === TransferType.E_TRANSFER) && (
+      {/* [DEPRECATED-ETRANSFER] E_TRANSFER powered-by removed, only show eBridge */}
+      {transferType === TransferType.E_BRIDGE && (
         <div className="flex-center powered-by">
-          <CustomSvgV3
-            className={transferType === TransferType.E_BRIDGE ? 'provider-ebridge-icon' : 'provider-etransfer-icon'}
-            type={transferType === TransferType.E_BRIDGE ? 'Provider=eBridge' : 'Provider=ETransfer'}
-          />
+          <CustomSvgV3 className="provider-ebridge-icon" type="Provider=eBridge" />
         </div>
       )}
     </div>

--- a/packages/web-extension-aelf/app/web/pages/Send/index.tsx
+++ b/packages/web-extension-aelf/app/web/pages/Send/index.tsx
@@ -34,10 +34,12 @@ import singleMessage from 'utils/singleMessage';
 import { usePromptLocationParams } from 'hooks/router';
 import { TSendLocationState } from 'types/router';
 import DisclaimerModal, { IDisclaimerProps, initDisclaimerData } from 'pages/components/DisclaimerModal';
-import { useCrossTransferByEtransfer } from 'hooks/useCrossTransferByEtransfer';
-import { CROSS_CHAIN_ETRANSFER_SUPPORT_SYMBOL } from '@portkey-wallet/utils/withdrawEOA';
-import { ExtensionContractBasic } from 'utils/sandboxUtil/ExtensionContractBasic';
-import { COMMON_PRIVATE } from '@portkey-wallet/constants';
+// [DEPRECATED-ETRANSFER] BEGIN - ETransfer logic removed, using eBridge for all cross-chain
+// import { useCrossTransferByEtransfer } from 'hooks/useCrossTransferByEtransfer';
+// import { CROSS_CHAIN_ETRANSFER_SUPPORT_SYMBOL } from '@portkey-wallet/utils/withdrawEOA';
+// import { ExtensionContractBasic } from 'utils/sandboxUtil/ExtensionContractBasic';
+// import { COMMON_PRIVATE } from '@portkey-wallet/constants';
+// [DEPRECATED-ETRANSFER] END
 import ToAddressInput, { IToAddressInputRef } from './components/ToAddressInput';
 import SelectNetwork, { INetworkItem } from './components/SelectNetwork';
 import AddressTypeSelect, { AddressTypeEnum, ExchangeTypeShow } from './components/AddressTypeSelect';
@@ -61,10 +63,12 @@ import { useContactNetworkConfig } from '@portkey-wallet/hooks/hooks-ca/config';
 import { useGetTransferFee } from 'hooks/transfer';
 import { useCurrentAccount } from '@portkey-wallet/hooks/hooks-eoa/wallet';
 import { useCurrentNetwork, useCurrentNetworkInfo } from '@portkey-wallet/hooks/hooks-eoa/network';
-import { INITIAL_TX_FEE } from '@portkey-wallet/constants/constants-eoa/fee';
-import InternalMessage from 'messages/InternalMessage';
-import { PortkeyMessageTypes } from 'messages/InternalMessageTypes';
-import { useCheckETransferIsRegistration } from 'hooks/etransfer';
+// [DEPRECATED-ETRANSFER] BEGIN - imports used by ETransfer logic removed
+// import { INITIAL_TX_FEE } from '@portkey-wallet/constants/constants-eoa/fee';
+// import InternalMessage from 'messages/InternalMessage';
+// import { PortkeyMessageTypes } from 'messages/InternalMessageTypes';
+// import { useCheckETransferIsRegistration } from 'hooks/etransfer';
+// [DEPRECATED-ETRANSFER] END
 export enum SendPageTypeEnum {
   token = 'token',
   nft = 'nft',
@@ -206,7 +210,9 @@ export default function Send() {
   const currentChain = useCurrentChain(chainId);
   const disclaimerData = useRef<IDisclaimerProps>(initDisclaimerData);
   const [disclaimerOpen, setDisclaimerOpen] = useState<boolean>(false);
-  const { withdraw, withdrawPreview } = useCrossTransferByEtransfer();
+  // [DEPRECATED-ETRANSFER] BEGIN
+  // const { withdraw, withdrawPreview } = useCrossTransferByEtransfer();
+  // [DEPRECATED-ETRANSFER] END
   const { getTokenConfig, getAELFChainInfoConfig, getEVMChainInfoConfig } = useGetEBridgeConfig();
   const { fetchContactSupportConfig } = useContactNetworkConfig();
   const [warning, setWarning] = useState<WarningKey | undefined>();
@@ -214,10 +220,12 @@ export default function Send() {
   // network list
   const [chainList, setChainList] = useState<INetworkItem[]>([]);
   const [targetNetwork, setTargetNetwork] = useState<INetworkItem>();
-  const recommendETransfer = useMemo(
-    () => targetNetwork?.serviceList?.find((ele) => ele?.serviceName?.toLocaleLowerCase()?.includes('transfer')),
-    [targetNetwork?.serviceList],
-  );
+  // [DEPRECATED-ETRANSFER] BEGIN
+  // const recommendETransfer = useMemo(
+  //   () => targetNetwork?.serviceList?.find((ele) => ele?.serviceName?.toLocaleLowerCase()?.includes('transfer')),
+  //   [targetNetwork?.serviceList],
+  // );
+  // [DEPRECATED-ETRANSFER] END
   const recommendEBridge = useMemo(
     () => targetNetwork?.serviceList?.find((ele) => ele?.serviceName?.toLocaleLowerCase()?.includes('bridge')),
     [targetNetwork?.serviceList],
@@ -242,14 +250,16 @@ export default function Send() {
     fetchContactSupportConfig();
   });
 
-  useCheckETransferIsRegistration(
-    useCallback(() => {
-      InternalMessage.payload(
-        PortkeyMessageTypes.SEND_CARD,
-        `token/${symbol}?detail=${JSON.stringify({ ...state, isRegisterSend: true })}`,
-      ).send();
-    }, [symbol, state]),
-  );
+  // [DEPRECATED-ETRANSFER] BEGIN
+  // useCheckETransferIsRegistration(
+  //   useCallback(() => {
+  //     InternalMessage.payload(
+  //       PortkeyMessageTypes.SEND_CARD,
+  //       `token/${symbol}?detail=${JSON.stringify({ ...state, isRegisterSend: true })}`,
+  //     ).send();
+  //   }, [symbol, state]),
+  // );
+  // [DEPRECATED-ETRANSFER] END
 
   const modalTipContent = useMemo(() => {
     return {
@@ -388,57 +398,63 @@ export default function Send() {
           amount: timesDecimals(amount, tokenInfo.decimals).toFixed(),
           toAddress: toAccount.address,
         });
-      } else if (transferType === TransferType.E_TRANSFER) {
-        let network = '';
-        if (isDIDAelfAddress(toAccount.address)) {
-          const arr = toAccount?.address.split('_');
-          network = arr[arr.length - 1];
-        } else {
-          network = targetNetwork?.network || getAddressChainId(toAccount?.address, 'AELF') || 'AELF';
-        }
-        console.log('params', {
-          chainId,
-          toAddress: toAccount.address,
-          network,
-          amount,
-          tokenInfo: {
-            address: tokenInfo.address,
-            symbol: tokenInfo.symbol,
-            decimals: Number(tokenInfo.decimals),
-          },
-        });
-        console.log('withdraw', {
-          chainId,
-          toAddress: toAccount.address,
-          network,
-          amount,
-          tokenInfo: {
-            address: tokenInfo.address,
-            symbol: tokenInfo.symbol,
-            decimals: Number(tokenInfo.decimals),
-          },
-        });
-
-        const crossTransferByEtransferResult = await withdraw({
-          chainId,
-          toAddress: toAccount.address,
-          network,
-          amount,
-          tokenInfo: {
-            address: tokenInfo.address,
-            symbol: tokenInfo.symbol,
-            decimals: Number(tokenInfo.decimals),
-          },
-        });
-
-        console.log('crossTransferByEtransferResult', crossTransferByEtransferResult);
+        // [DEPRECATED-ETRANSFER] BEGIN - E_TRANSFER logic removed, using eBridge for all cross-chain
+        // } else if (transferType === TransferType.E_TRANSFER) {
+        //   let network = '';
+        //   if (isDIDAelfAddress(toAccount.address)) {
+        //     const arr = toAccount?.address.split('_');
+        //     network = arr[arr.length - 1];
+        //   } else {
+        //     network = targetNetwork?.network || getAddressChainId(toAccount?.address, 'AELF') || 'AELF';
+        //   }
+        //   console.log('params', {
+        //     chainId,
+        //     toAddress: toAccount.address,
+        //     network,
+        //     amount,
+        //     tokenInfo: {
+        //       address: tokenInfo.address,
+        //       symbol: tokenInfo.symbol,
+        //       decimals: Number(tokenInfo.decimals),
+        //     },
+        //   });
+        //   console.log('withdraw', {
+        //     chainId,
+        //     toAddress: toAccount.address,
+        //     network,
+        //     amount,
+        //     tokenInfo: {
+        //       address: tokenInfo.address,
+        //       symbol: tokenInfo.symbol,
+        //       decimals: Number(tokenInfo.decimals),
+        //     },
+        //   });
+        //   const crossTransferByEtransferResult = await withdraw({
+        //     chainId,
+        //     toAddress: toAccount.address,
+        //     network,
+        //     amount,
+        //     tokenInfo: {
+        //       address: tokenInfo.address,
+        //       symbol: tokenInfo.symbol,
+        //       decimals: Number(tokenInfo.decimals),
+        //     },
+        //   });
+        //   console.log('crossTransferByEtransferResult', crossTransferByEtransferResult);
+        // [DEPRECATED-ETRANSFER] END
       } else if (transferType === TransferType.E_BRIDGE) {
         if (!wallet?.address) {
           throw 'currentWallet is null';
         }
         setEBridgeFeeNotEnough(false);
         const fromChainInfo = getAELFChainInfoConfig(tokenInfo.chainId);
-        const toChainInfo = getEVMChainInfoConfig(targetNetwork?.network || '');
+        // Support both aelf internal cross-chain and aelf -> EVM cross-chain
+        const isAelfInternalCrossChain =
+          isCrossChain(toAccount.address, chainId) && isDIDAelfAddress(toAccount.address);
+        const toChainId = isAelfInternalCrossChain ? getAddressChainId(toAccount.address, chainId) : null;
+        const toChainInfo = isAelfInternalCrossChain
+          ? getAELFChainInfoConfig(toChainId || 'AELF')
+          : getEVMChainInfoConfig(targetNetwork?.network || '');
 
         const tokenEBridgeInfo = getTokenConfig(tokenInfo.symbol);
         const bridge = new CrossEBridgeExtension(
@@ -516,7 +532,7 @@ export default function Send() {
     targetNetwork?.imageUrl,
     amount,
     chainId,
-    withdraw,
+    // [DEPRECATED-ETRANSFER] withdraw removed
     getAELFChainInfoConfig,
     getEVMChainInfoConfig,
     getTokenConfig,
@@ -527,81 +543,74 @@ export default function Send() {
     currentNetworkInfo.walletType,
   ]);
 
-  const { max: maxFee, crossChain: crossChainFee, etransfer: etransferFee } = useGetTxFee(chainId);
+  const { max: maxFee, crossChain: crossChainFee } = useGetTxFee(chainId);
 
-  const getEtransferAllowance = useCallback(
-    async (token: BaseToken) => {
-      if (!currentChain) throw 'No currentChain';
-
-      const tokenContract = new ExtensionContractBasic({
-        rpcUrl: currentChain.endPoint,
-        contractAddress: currentChain.defaultToken.address,
-        privateKey: COMMON_PRIVATE,
-      });
-      const allowanceRes = await tokenContract.callViewMethod('GetAllowance', {
-        symbol: token.symbol,
-        owner: wallet?.address,
-        spender: currentNetworkInfo.eTransferCA?.[token.chainId],
-      });
-
-      if (allowanceRes?.error) throw allowanceRes?.error;
-      const allowance = divDecimals(allowanceRes.data.allowance ?? allowanceRes.data.amount ?? 0, token.decimals);
-      return allowance;
-    },
-    [currentChain, currentNetworkInfo.eTransferCA, wallet?.address],
-  );
-
-  const getEtransferMaxFee = useCallback(
-    // approve fee
-    async ({ amount }: { amount: string }) => {
-      const token = tokenInfo;
-      try {
-        const arr = toAccount.address.split('_');
-        const network = arr[arr.length - 1];
-
-        console.log(
-          {
-            chainId: token.chainId,
-            address: toAccount.address,
-            symbol: token.symbol,
-            network,
-            currentAccountAddress: wallet?.address || '',
-          },
-          '======getEtransferMaxFee',
-        );
-
-        const [{ withdrawInfo }, allowance] = await Promise.all([
-          withdrawPreview(
-            {
-              chainId: token.chainId,
-              address: toAccount.address,
-              symbol: token.symbol,
-              network,
-              currentAccountAddress: wallet?.address || '',
-            },
-            true,
-          ),
-          getEtransferAllowance(token),
-        ]);
-
-        console.log(withdrawInfo, allowance, 'checkEtransferMaxFee==');
-
-        let _etransferFee = etransferFee;
-
-        const isGTMax = withdrawInfo?.maxAmount ? ZERO.plus(amount).lte(withdrawInfo.maxAmount) : true;
-        const isLTMin = withdrawInfo?.minAmount ? ZERO.plus(amount).gte(withdrawInfo.minAmount) : true;
-        const amountAllowed = withdrawInfo ? isGTMax && isLTMin : false;
-
-        if (amountAllowed && allowance.gte(amount)) _etransferFee = 0;
-        console.log(_etransferFee, '_etransferFee==checkEtransferMaxFee');
-        return _etransferFee.toString();
-      } catch (error) {
-        console.error('checkEtransferMaxFee:', error);
-        return etransferFee.toString();
-      }
-    },
-    [tokenInfo, toAccount.address, wallet?.address, withdrawPreview, getEtransferAllowance, etransferFee],
-  );
+  // [DEPRECATED-ETRANSFER] BEGIN - ETransfer allowance and fee functions removed
+  // const { etransfer: etransferFee } = useGetTxFee(chainId);
+  // const getEtransferAllowance = useCallback(
+  //   async (token: BaseToken) => {
+  //     if (!currentChain) throw 'No currentChain';
+  //     const tokenContract = new ExtensionContractBasic({
+  //       rpcUrl: currentChain.endPoint,
+  //       contractAddress: currentChain.defaultToken.address,
+  //       privateKey: COMMON_PRIVATE,
+  //     });
+  //     const allowanceRes = await tokenContract.callViewMethod('GetAllowance', {
+  //       symbol: token.symbol,
+  //       owner: wallet?.address,
+  //       spender: currentNetworkInfo.eTransferCA?.[token.chainId],
+  //     });
+  //     if (allowanceRes?.error) throw allowanceRes?.error;
+  //     const allowance = divDecimals(allowanceRes.data.allowance ?? allowanceRes.data.amount ?? 0, token.decimals);
+  //     return allowance;
+  //   },
+  //   [currentChain, currentNetworkInfo.eTransferCA, wallet?.address],
+  // );
+  // const getEtransferMaxFee = useCallback(
+  //   async ({ amount }: { amount: string }) => {
+  //     const token = tokenInfo;
+  //     try {
+  //       const arr = toAccount.address.split('_');
+  //       const network = arr[arr.length - 1];
+  //       console.log(
+  //         {
+  //           chainId: token.chainId,
+  //           address: toAccount.address,
+  //           symbol: token.symbol,
+  //           network,
+  //           currentAccountAddress: wallet?.address || '',
+  //         },
+  //         '======getEtransferMaxFee',
+  //       );
+  //       const [{ withdrawInfo }, allowance] = await Promise.all([
+  //         withdrawPreview(
+  //           {
+  //             chainId: token.chainId,
+  //             address: toAccount.address,
+  //             symbol: token.symbol,
+  //             network,
+  //             currentAccountAddress: wallet?.address || '',
+  //           },
+  //           true,
+  //         ),
+  //         getEtransferAllowance(token),
+  //       ]);
+  //       console.log(withdrawInfo, allowance, 'checkEtransferMaxFee==');
+  //       let _etransferFee = etransferFee;
+  //       const isGTMax = withdrawInfo?.maxAmount ? ZERO.plus(amount).lte(withdrawInfo.maxAmount) : true;
+  //       const isLTMin = withdrawInfo?.minAmount ? ZERO.plus(amount).gte(withdrawInfo.minAmount) : true;
+  //       const amountAllowed = withdrawInfo ? isGTMax && isLTMin : false;
+  //       if (amountAllowed && allowance.gte(amount)) _etransferFee = 0;
+  //       console.log(_etransferFee, '_etransferFee==checkEtransferMaxFee');
+  //       return _etransferFee.toString();
+  //     } catch (error) {
+  //       console.error('checkEtransferMaxFee:', error);
+  //       return etransferFee.toString();
+  //     }
+  //   },
+  //   [tokenInfo, toAccount.address, wallet?.address, withdrawPreview, getEtransferAllowance, etransferFee],
+  // );
+  // [DEPRECATED-ETRANSFER] END
 
   const updateBalance = useCallback(async () => {
     if (!currentChain || !wallet?.address) return;
@@ -625,7 +634,8 @@ export default function Send() {
     if (!balance) return setMaxAmount('0');
 
     const balanceBN = divDecimals(balance, tokenInfo.decimals);
-    const balanceStr = balanceBN.toString();
+    // [DEPRECATED-ETRANSFER] balanceStr was used by getEtransferMaxFee
+    // const balanceStr = balanceBN.toString();
 
     // balance 0
     if (balanceBN.isEqualTo(0)) {
@@ -651,11 +661,13 @@ export default function Send() {
       console.log('FEE ERROR');
     }
 
-    const eTransferFee = await getEtransferMaxFee({ amount: balanceStr });
-
-    const _max = fee
-      ? balanceBN.minus(eTransferFee)
-      : ZERO.plus(divDecimals(balance, tokenInfo.decimals)).minus(maxFee).minus(eTransferFee);
+    // [DEPRECATED-ETRANSFER] BEGIN - ETransfer fee calculation removed
+    // const eTransferFee = await getEtransferMaxFee({ amount: balanceStr });
+    // const _max = fee
+    //   ? balanceBN.minus(eTransferFee)
+    //   : ZERO.plus(divDecimals(balance, tokenInfo.decimals)).minus(maxFee).minus(eTransferFee);
+    // [DEPRECATED-ETRANSFER] END
+    const _max = fee ? balanceBN.minus(fee) : ZERO.plus(divDecimals(balance, tokenInfo.decimals)).minus(maxFee);
 
     setMaxAmount(_max.gt(ZERO) ? _max.toFixed() : '0');
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -687,7 +699,8 @@ export default function Send() {
         console.log('wallet address does not exist');
         return { status: false };
       }
-      const tokenSymbol = tokenInfo.symbol;
+      // [DEPRECATED-ETRANSFER] tokenSymbol was used by ETransfer logic
+      // const tokenSymbol = tokenInfo.symbol;
 
       // CHECK 4: balance
       const [result, defaultTokenResult] = await Promise.all([
@@ -711,7 +724,8 @@ export default function Send() {
         }),
       ]);
 
-      const defaultTokenBalance = timesDecimals(defaultTokenResult.result.balance, defaultToken.decimals);
+      // [DEPRECATED-ETRANSFER] defaultTokenBalance was used by ETransfer fee check
+      // const defaultTokenBalance = timesDecimals(defaultTokenResult.result.balance, defaultToken.decimals);
       console.log(result, defaultTokenResult, '=====result');
 
       setBalance(result.result.balance);
@@ -743,90 +757,85 @@ export default function Send() {
 
       // CHECK 6: fee check
       let networkFee: string | undefined;
-      let networkFeeUnit: string | undefined;
+      const networkFeeUnit: string | undefined = 'ELF';
       let transactionFee: string | undefined;
       let transactionUnit: string | undefined;
       let receiveAmount: string | undefined;
       let receiveAmountUsd: string | undefined;
       let transferType = TransferType.GENERAL_SAME_CHAIN;
 
+      // [DEPRECATED-ETRANSFER] BEGIN - CHECK 6.1 ETransfer to EVM removed, using eBridge instead
       // CHECK 6.1 isRecommendEtransfer(to evm) fee check
-      if (
-        warning === WarningKey.MAKE_SURE_SUPPORT_PLATFORM &&
-        recommendETransfer &&
-        ZERO.plus(recommendETransfer?.maxAmount).isGreaterThan(amount)
-      ) {
-        console.log('6.1');
-
-        try {
-          const [{ withdrawInfo }, allowance] = await Promise.all([
-            withdrawPreview({
-              chainId,
-              address: toAccount.address,
-              symbol: tokenSymbol,
-              amount,
-              network: targetNetwork?.network || '',
-              currentAccountAddress: wallet?.address || '',
-              isMainnet: currentNetwork === 'MAINNET',
-            }),
-            getEtransferAllowance(tokenInfo),
-          ]);
-          console.log(withdrawInfo, '=====withdrawInfo');
-
-          let _etransferFee = etransferFee;
-
-          const isGTMax = withdrawInfo?.maxAmount ? ZERO.plus(amount).lte(withdrawInfo.maxAmount) : true;
-          const isLTMin = withdrawInfo?.minAmount ? ZERO.plus(amount).gte(withdrawInfo.minAmount) : true;
-
-          const amountAllowed = withdrawInfo ? isGTMax && isLTMin : false;
-
-          if ((amountAllowed && allowance.gte(amount)) || tokenSymbol !== defaultToken.symbol) _etransferFee = 0;
-
-          if (ZERO.plus(amount).plus(_etransferFee).gt(divDecimals(balance, tokenInfo.decimals))) {
-            setAmountErrMsg(TransactionError.TOKEN_NOT_ENOUGH);
-            return { status: false };
-          }
-
-          if (amountAllowed) {
-            networkFee = withdrawInfo?.aelfTransactionFee;
-            networkFeeUnit = 'ELF';
-            transactionFee = withdrawInfo.transactionFee;
-            transactionUnit = withdrawInfo.transactionUnit;
-            receiveAmount = withdrawInfo?.receiveAmount;
-            receiveAmountUsd = withdrawInfo?.receiveAmountUsd;
-            transferType = TransferType.E_TRANSFER;
-            setNetworkFee(networkFee);
-            setNetworkFeeUnit(networkFeeUnit);
-            setReceiveAmount(receiveAmount);
-            setReceiveAmountUsd(receiveAmountUsd);
-            setTransactionFee(transactionFee);
-            setTransactionUnit(transactionUnit);
-            console.log('transferType1', transferType);
-            setTransferType(transferType);
-            return {
-              status: true,
-              networkFee,
-              networkFeeUnit,
-              receiveAmount,
-              receiveAmountUsd,
-              transactionFee,
-              transactionUnit,
-              transferType,
-              targetNetwork: targetNetwork,
-            };
-          } else {
-            setAmountErrMsg(
-              getLimitTips(tokenInfo.label || tokenInfo.symbol, withdrawInfo.minAmount, withdrawInfo.maxAmount),
-            );
-            throw 'eTransfer err';
-          }
-        } catch (error) {
-          console.log('isRecommendEtransfer err', error);
-          return { status: false };
-        } finally {
-          setBtnLoading(false);
-        }
-      }
+      // if (
+      //   warning === WarningKey.MAKE_SURE_SUPPORT_PLATFORM &&
+      //   recommendETransfer &&
+      //   ZERO.plus(recommendETransfer?.maxAmount).isGreaterThan(amount)
+      // ) {
+      //   console.log('6.1');
+      //   try {
+      //     const [{ withdrawInfo }, allowance] = await Promise.all([
+      //       withdrawPreview({
+      //         chainId,
+      //         address: toAccount.address,
+      //         symbol: tokenSymbol,
+      //         amount,
+      //         network: targetNetwork?.network || '',
+      //         currentAccountAddress: wallet?.address || '',
+      //         isMainnet: currentNetwork === 'MAINNET',
+      //       }),
+      //       getEtransferAllowance(tokenInfo),
+      //     ]);
+      //     console.log(withdrawInfo, '=====withdrawInfo');
+      //     let _etransferFee = etransferFee;
+      //     const isGTMax = withdrawInfo?.maxAmount ? ZERO.plus(amount).lte(withdrawInfo.maxAmount) : true;
+      //     const isLTMin = withdrawInfo?.minAmount ? ZERO.plus(amount).gte(withdrawInfo.minAmount) : true;
+      //     const amountAllowed = withdrawInfo ? isGTMax && isLTMin : false;
+      //     if ((amountAllowed && allowance.gte(amount)) || tokenSymbol !== defaultToken.symbol) _etransferFee = 0;
+      //     if (ZERO.plus(amount).plus(_etransferFee).gt(divDecimals(balance, tokenInfo.decimals))) {
+      //       setAmountErrMsg(TransactionError.TOKEN_NOT_ENOUGH);
+      //       return { status: false };
+      //     }
+      //     if (amountAllowed) {
+      //       networkFee = withdrawInfo?.aelfTransactionFee;
+      //       networkFeeUnit = 'ELF';
+      //       transactionFee = withdrawInfo.transactionFee;
+      //       transactionUnit = withdrawInfo.transactionUnit;
+      //       receiveAmount = withdrawInfo?.receiveAmount;
+      //       receiveAmountUsd = withdrawInfo?.receiveAmountUsd;
+      //       transferType = TransferType.E_TRANSFER;
+      //       setNetworkFee(networkFee);
+      //       setNetworkFeeUnit(networkFeeUnit);
+      //       setReceiveAmount(receiveAmount);
+      //       setReceiveAmountUsd(receiveAmountUsd);
+      //       setTransactionFee(transactionFee);
+      //       setTransactionUnit(transactionUnit);
+      //       console.log('transferType1', transferType);
+      //       setTransferType(transferType);
+      //       return {
+      //         status: true,
+      //         networkFee,
+      //         networkFeeUnit,
+      //         receiveAmount,
+      //         receiveAmountUsd,
+      //         transactionFee,
+      //         transactionUnit,
+      //         transferType,
+      //         targetNetwork: targetNetwork,
+      //       };
+      //     } else {
+      //       setAmountErrMsg(
+      //         getLimitTips(tokenInfo.label || tokenInfo.symbol, withdrawInfo.minAmount, withdrawInfo.maxAmount),
+      //       );
+      //       throw 'eTransfer err';
+      //     }
+      //   } catch (error) {
+      //     console.log('isRecommendEtransfer err', error);
+      //     return { status: false };
+      //   } finally {
+      //     setBtnLoading(false);
+      //   }
+      // }
+      // [DEPRECATED-ETRANSFER] END
 
       // CHECK 6.2 isRecommendEBridge(to evm) fee check
       if (warning === WarningKey.MAKE_SURE_SUPPORT_PLATFORM && recommendEBridge) {
@@ -893,77 +902,140 @@ export default function Send() {
         }
       }
 
-      // CHECK 6.3 CrossChain in aelf support ETransfer
-      if (isCrossChain(toAccount.address, chainId) && CROSS_CHAIN_ETRANSFER_SUPPORT_SYMBOL.includes(tokenSymbol)) {
-        console.log('CHECK 6.3');
+      // [DEPRECATED-ETRANSFER] BEGIN - CHECK 6.3 ETransfer for aelf internal cross-chain removed
+      // Now using eBridge for aelf internal cross-chain (CHECK 6.3-NEW below)
+      // if (isCrossChain(toAccount.address, chainId) && CROSS_CHAIN_ETRANSFER_SUPPORT_SYMBOL.includes(tokenSymbol)) {
+      //   console.log('CHECK 6.3');
+      //   const [{ withdrawInfo }, allowance] = await Promise.all([
+      //     withdrawPreview({
+      //       symbol: tokenInfo.symbol,
+      //       address: toAccount.address,
+      //       chainId: tokenInfo.chainId,
+      //       amount,
+      //       network: getAddressChainId(toAccount.address, 'AELF') || 'AELF',
+      //       currentAccountAddress: wallet?.address || '',
+      //       isMainnet: currentNetwork === 'MAINNET',
+      //     }),
+      //     getEtransferAllowance(tokenInfo),
+      //   ]);
+      //   console.log(withdrawInfo, '====withdrawInfo');
+      //   let _etransferFee = etransferFee;
+      //   const isGTMax = withdrawInfo?.maxAmount ? ZERO.plus(amount).lte(withdrawInfo.maxAmount) : true;
+      //   const isLTMin = withdrawInfo?.minAmount ? ZERO.plus(amount).gte(withdrawInfo.minAmount) : true;
+      //   const amountAllowed = withdrawInfo ? isGTMax && isLTMin : false;
+      //   if ((amountAllowed && allowance.gte(amount)) || tokenSymbol !== defaultToken.symbol) _etransferFee = 0;
+      //   if (ZERO.plus(amount).plus(_etransferFee).gt(divDecimals(balance, tokenInfo.decimals))) {
+      //     setAmountErrMsg(TransactionError.TOKEN_NOT_ENOUGH);
+      //     return { status: false };
+      //   }
+      //   if (defaultTokenBalance.lt(INITIAL_TX_FEE.etransfer)) {
+      //     setAmountErrMsg(TransactionError.FEE_NOT_ENOUGH);
+      //     return { status: false };
+      //   }
+      //   if (amountAllowed) {
+      //     networkFee = withdrawInfo?.aelfTransactionFee;
+      //     networkFeeUnit = 'ELF';
+      //     transactionFee = withdrawInfo.transactionFee;
+      //     transactionUnit = withdrawInfo.transactionUnit;
+      //     receiveAmount = withdrawInfo?.receiveAmount;
+      //     receiveAmountUsd = withdrawInfo?.receiveAmountUsd;
+      //     transferType = TransferType.E_TRANSFER;
+      //     setNetworkFee(networkFee);
+      //     setNetworkFeeUnit(networkFeeUnit);
+      //     setReceiveAmount(receiveAmount);
+      //     setReceiveAmountUsd(receiveAmountUsd);
+      //     setTransactionFee(transactionFee);
+      //     setTransactionUnit(transactionUnit);
+      //     console.log('transferType3', transferType);
+      //     setTransferType(transferType);
+      //     return {
+      //       status: true,
+      //       networkFee,
+      //       networkFeeUnit,
+      //       receiveAmount,
+      //       receiveAmountUsd,
+      //       transactionFee,
+      //       transactionUnit,
+      //       transferType,
+      //       targetNetwork: targetNetwork,
+      //     };
+      //   }
+      // }
+      // [DEPRECATED-ETRANSFER] END
 
-        const [{ withdrawInfo }, allowance] = await Promise.all([
-          withdrawPreview({
-            symbol: tokenInfo.symbol,
-            address: toAccount.address,
-            chainId: tokenInfo.chainId,
-            amount,
-            network: getAddressChainId(toAccount.address, 'AELF') || 'AELF',
-            currentAccountAddress: wallet?.address || '',
-            isMainnet: currentNetwork === 'MAINNET',
-          }),
-          getEtransferAllowance(tokenInfo),
-        ]);
-        console.log(withdrawInfo, '====withdrawInfo');
+      // CHECK 6.3-NEW: aelf internal cross-chain using eBridge
+      if (isCrossChain(toAccount.address, chainId)) {
+        console.log('CHECK 6.3-NEW: aelf internal cross-chain via eBridge');
+        try {
+          setBtnLoading(true);
+          const toChainId = getAddressChainId(toAccount.address, chainId) || 'AELF';
+          const fromChainInfo = getAELFChainInfoConfig(tokenInfo.chainId);
+          const toChainInfo = getAELFChainInfoConfig(toChainId);
+          const tokenEBridgeInfo = getTokenConfig(tokenInfo.symbol);
 
-        let _etransferFee = etransferFee;
+          // Check if token is supported by eBridge for aelf internal cross-chain
+          if (!tokenEBridgeInfo) {
+            console.log('Token not supported by eBridge, falling back to GENERAL_CROSS_CHAIN');
+            // Fall through to CHECK 6.4 for native cross-chain
+          } else {
+            const bridge = new CrossEBridgeExtension(
+              {
+                fromChainInfo,
+                toChainInfo,
+                tokenInfo: tokenEBridgeInfo,
+              },
+              pin,
+              wallet,
+              currentChain,
+            );
 
-        const isGTMax = withdrawInfo?.maxAmount ? ZERO.plus(amount).lte(withdrawInfo.maxAmount) : true;
-        const isLTMin = withdrawInfo?.minAmount ? ZERO.plus(amount).gte(withdrawInfo.minAmount) : true;
+            receiveAmount = amount;
+            receiveAmountUsd = ZERO.plus(amount).times(tokenPriceObject[tokenInfo.symbol]).toString();
 
-        const amountAllowed = withdrawInfo ? isGTMax && isLTMin : false;
+            // fee
+            const f = await bridge.getELFFee();
 
-        if ((amountAllowed && allowance.gte(amount)) || tokenSymbol !== defaultToken.symbol) _etransferFee = 0;
-
-        if (ZERO.plus(amount).plus(_etransferFee).gt(divDecimals(balance, tokenInfo.decimals))) {
-          setAmountErrMsg(TransactionError.TOKEN_NOT_ENOUGH);
-          return { status: false };
-        }
-
-        if (defaultTokenBalance.lt(INITIAL_TX_FEE.etransfer)) {
-          setAmountErrMsg(TransactionError.FEE_NOT_ENOUGH);
-          return { status: false };
-        }
-        if (amountAllowed) {
-          networkFee = withdrawInfo?.aelfTransactionFee;
-
-          // if(defaultTokenResult.result.balance)
-
-          networkFeeUnit = 'ELF';
-          transactionFee = withdrawInfo.transactionFee;
-          transactionUnit = withdrawInfo.transactionUnit;
-          receiveAmount = withdrawInfo?.receiveAmount;
-          receiveAmountUsd = withdrawInfo?.receiveAmountUsd;
-          transferType = TransferType.E_TRANSFER;
-          setNetworkFee(networkFee);
-          setNetworkFeeUnit(networkFeeUnit);
-          setReceiveAmount(receiveAmount);
-          setReceiveAmountUsd(receiveAmountUsd);
-          setTransactionFee(transactionFee);
-          setTransactionUnit(transactionUnit);
-          console.log('transferType3', transferType);
-          setTransferType(transferType);
-          return {
-            status: true,
-            networkFee,
-            networkFeeUnit,
-            receiveAmount,
-            receiveAmountUsd,
-            transactionFee,
-            transactionUnit,
-            transferType,
-            targetNetwork: targetNetwork,
-          };
+            // limit
+            const limit = await bridge.getLimit();
+            console.log('getELFFee', f, 'getLimit', limit);
+            const targetLimit = getSmallerValue(limit.remain, limit.currentCapacity);
+            if (limit.isEnable && timesDecimals(amount, tokenInfo.decimals || '0').isGreaterThan(targetLimit)) {
+              setAmountErrMsg(getLimitTips(tokenInfo.symbol, '0', formatAmountShow(targetLimit)));
+              return { status: false };
+            }
+            transactionFee = divDecimals(f, defaultToken.decimals).toString();
+            transactionUnit = 'ELF';
+            transferType = TransferType.E_BRIDGE;
+            setNetworkFee(networkFee);
+            setNetworkFeeUnit(networkFeeUnit);
+            setReceiveAmount(receiveAmount);
+            setReceiveAmountUsd(receiveAmountUsd);
+            setTransactionFee(transactionFee);
+            setTransactionUnit(transactionUnit);
+            console.log('transferType3-NEW', transferType);
+            setTransferType(transferType);
+            return {
+              status: true,
+              networkFee,
+              networkFeeUnit,
+              transactionFee,
+              transactionUnit,
+              receiveAmount,
+              receiveAmountUsd,
+              transferType,
+              targetNetwork,
+            };
+          }
+        } catch (error) {
+          console.log('aelf internal cross-chain via eBridge err', error);
+          // Fall through to CHECK 6.4 for native cross-chain as fallback
+        } finally {
+          setBtnLoading(false);
         }
       }
 
       // CHECK 6.4 SameChain or Default CrossChain
-      networkFeeUnit = 'ELF';
+      // networkFeeUnit already set to 'ELF' in declaration
       transferType = isCrossChain(toAccount.address, chainId)
         ? TransferType.GENERAL_CROSS_CHAIN
         : TransferType.GENERAL_SAME_CHAIN;
@@ -1028,7 +1100,7 @@ export default function Send() {
     currentNetworkInfo.walletType,
     type,
     warning,
-    recommendETransfer,
+    // [DEPRECATED-ETRANSFER] recommendETransfer removed
     amount,
     recommendEBridge,
     toAccount,
@@ -1038,11 +1110,9 @@ export default function Send() {
     defaultToken.symbol,
     defaultToken.decimals,
     crossChainFee,
-    withdrawPreview,
+    // [DEPRECATED-ETRANSFER] withdrawPreview, getEtransferAllowance, etransferFee removed
     targetNetwork,
     currentNetwork,
-    getEtransferAllowance,
-    etransferFee,
     getAELFChainInfoConfig,
     getEVMChainInfoConfig,
     getTokenConfig,

--- a/packages/web-extension-aelf/app/web/pages/Send/utils/index.ts
+++ b/packages/web-extension-aelf/app/web/pages/Send/utils/index.ts
@@ -41,16 +41,18 @@ export function getSmallerValue(v1: string, v2: string) {
 }
 
 export const getEstimatedTime = (targetNetwork: INetworkItem, transferType: TransferType) => {
-  const transferItem = targetNetwork?.serviceList?.find((ele) =>
-    ele?.serviceName?.toLocaleLowerCase()?.includes('transfer'),
-  );
+  // [DEPRECATED-ETRANSFER] E_TRANSFER removed
+  // const transferItem = targetNetwork?.serviceList?.find((ele) =>
+  //   ele?.serviceName?.toLocaleLowerCase()?.includes('transfer'),
+  // );
   const bridgeItem = targetNetwork?.serviceList?.find((ele) =>
     ele?.serviceName?.toLocaleLowerCase()?.includes('bridge'),
   );
 
-  if (transferType === TransferType.E_TRANSFER) {
-    return transferItem?.multiConfirmTime;
-  }
+  // [DEPRECATED-ETRANSFER] E_TRANSFER case removed
+  // if (transferType === TransferType.E_TRANSFER) {
+  //   return transferItem?.multiConfirmTime;
+  // }
   if (transferType === TransferType.E_BRIDGE) {
     return bridgeItem?.multiConfirmTime;
   }

--- a/packages/web-extension-aelf/app/web/sandboxUtil.ts
+++ b/packages/web-extension-aelf/app/web/sandboxUtil.ts
@@ -7,8 +7,10 @@ import { customFetch } from '@portkey-wallet/utils/fetch';
 import { getContractBasic, getTxResult } from '@portkey-wallet/contracts/utils';
 import { ContractBasic } from '@portkey-wallet/contracts/utils/ContractBasic';
 import UISdkSandboxEventTypes from 'messages/UISdkSandboxEventTypes';
-import { ICrossTransferInitOption, IWithdrawParams } from '@portkey-wallet/utils/withdrawEOA/types';
-import CrossTransfer from '@portkey-wallet/utils/withdrawEOA';
+// [DEPRECATED-ETRANSFER] BEGIN - ETransfer imports removed
+// import { ICrossTransferInitOption, IWithdrawParams } from '@portkey-wallet/utils/withdrawEOA/types';
+// import CrossTransfer from '@portkey-wallet/utils/withdrawEOA';
+// [DEPRECATED-ETRANSFER] END
 import { IStorageSuite } from '@portkey/types';
 import AElf from 'aelf-sdk';
 import { handleErrorMessage } from '@portkey/did-ui-react';
@@ -34,7 +36,8 @@ export class BaseAsyncStorage implements IStorageSuite {
   }
 }
 
-const asyncStorage = new BaseAsyncStorage();
+// [DEPRECATED-ETRANSFER] asyncStorage was used by ETransfer, now deprecated
+// const asyncStorage = new BaseAsyncStorage();
 
 interface useBalancesProps {
   tokens: TokenItemType | TokenItemType[];
@@ -100,9 +103,11 @@ class SandboxUtil {
         case SandboxEventTypes.getTransactionRaw:
           SandboxUtil.getTransactionRaw(event, SandboxUtil.callback);
           break;
-        case SandboxEventTypes.etransferCrossTransfer:
-          SandboxUtil.etransferCrossTransfer(event, SandboxUtil.callback);
-          break;
+        // [DEPRECATED-ETRANSFER] BEGIN - etransferCrossTransfer case removed
+        // case SandboxEventTypes.etransferCrossTransfer:
+        //   SandboxUtil.etransferCrossTransfer(event, SandboxUtil.callback);
+        //   break;
+        // [DEPRECATED-ETRANSFER] END
         case SandboxEventTypes.eBridgeCrossTransfer:
           SandboxUtil.eBridgeCrossTransfer(event, SandboxUtil.callback);
           break;
@@ -401,48 +406,48 @@ class SandboxUtil {
     }
   }
 
-  static async etransferCrossTransfer(event: MessageEvent<any>, callback: SendBack) {
-    const data = event.data.data ?? {};
-    try {
-      const { options: _options, params: _params, chainType } = data;
-      if (chainType !== 'aelf') throw 'Not support';
-      const options: Omit<ICrossTransferInitOption, 'storage'> = JSON.parse(_options);
-      const params: Omit<IWithdrawParams, 'tokenContract' | 'portkeyContract'> = JSON.parse(_params);
-      console.log(data, 'etransferCrossTransfer===', options, params);
-      const crossTransfer = new CrossTransfer();
-      crossTransfer.init({ ...options, storage: asyncStorage });
-      const chainInfo = options.chainList.find((chain) => chain.chainId === params.chainId);
-      const rpcUrl = chainInfo?.endPoint;
-      if (!rpcUrl) throw 'Can not get rpcUrl';
-      const privateKey = AElf.wallet.AESDecrypt(options.account.AESEncryptPrivateKey, options.pin);
-      const tokenContract = await SandboxUtil._getELFSendContract(
-        rpcUrl,
-        chainInfo.defaultToken.address || '',
-        privateKey,
-      );
-      const result = await crossTransfer.withdraw({ ...params, tokenContract });
-      if (!result?.transactionId) throw 'Transfer error';
-      const aelf = getAelfInstance(rpcUrl);
-
-      const txResult = await getTxResult(aelf, result.transactionId);
-      console.log(txResult, 'txResult===etransferCrossTransfer');
-
-      return callback(event, {
-        code: SandboxErrorCode.success,
-        message: result,
-        sid: data.sid,
-      });
-    } catch (e) {
-      console.log(e, 'etransferCrossTransfer==error');
-      const message = handleErrorMessage(e, 'Transfer error');
-      console.log(message, 'message==etransferCrossTransfer');
-      return callback(event, {
-        code: SandboxErrorCode.error,
-        message,
-        sid: data.sid,
-      });
-    }
-  }
+  // [DEPRECATED-ETRANSFER] BEGIN - etransferCrossTransfer method deprecated
+  // static async etransferCrossTransfer(event: MessageEvent<any>, callback: SendBack) {
+  //   const data = event.data.data ?? {};
+  //   try {
+  //     const { options: _options, params: _params, chainType } = data;
+  //     if (chainType !== 'aelf') throw 'Not support';
+  //     const options: Omit<ICrossTransferInitOption, 'storage'> = JSON.parse(_options);
+  //     const params: Omit<IWithdrawParams, 'tokenContract' | 'portkeyContract'> = JSON.parse(_params);
+  //     console.log(data, 'etransferCrossTransfer===', options, params);
+  //     const crossTransfer = new CrossTransfer();
+  //     crossTransfer.init({ ...options, storage: asyncStorage });
+  //     const chainInfo = options.chainList.find((chain) => chain.chainId === params.chainId);
+  //     const rpcUrl = chainInfo?.endPoint;
+  //     if (!rpcUrl) throw 'Can not get rpcUrl';
+  //     const privateKey = AElf.wallet.AESDecrypt(options.account.AESEncryptPrivateKey, options.pin);
+  //     const tokenContract = await SandboxUtil._getELFSendContract(
+  //       rpcUrl,
+  //       chainInfo.defaultToken.address || '',
+  //       privateKey,
+  //     );
+  //     const result = await crossTransfer.withdraw({ ...params, tokenContract });
+  //     if (!result?.transactionId) throw 'Transfer error';
+  //     const aelf = getAelfInstance(rpcUrl);
+  //     const txResult = await getTxResult(aelf, result.transactionId);
+  //     console.log(txResult, 'txResult===etransferCrossTransfer');
+  //     return callback(event, {
+  //       code: SandboxErrorCode.success,
+  //       message: result,
+  //       sid: data.sid,
+  //     });
+  //   } catch (e) {
+  //     console.log(e, 'etransferCrossTransfer==error');
+  //     const message = handleErrorMessage(e, 'Transfer error');
+  //     console.log(message, 'message==etransferCrossTransfer');
+  //     return callback(event, {
+  //       code: SandboxErrorCode.error,
+  //       message,
+  //       sid: data.sid,
+  //     });
+  //   }
+  // }
+  // [DEPRECATED-ETRANSFER] END
 
   static async eBridgeCrossTransfer(event: MessageEvent<any>, callback: SendBack) {
     const data = event.data.data ?? {};

--- a/packages/web-extension-aelf/app/web/utils/sandboxUtil/extension-cross-chain.ts
+++ b/packages/web-extension-aelf/app/web/utils/sandboxUtil/extension-cross-chain.ts
@@ -2,34 +2,40 @@ import { IChainItemType } from '@portkey-wallet/types/types-ca/chain';
 import { TAccountInfo } from '@portkey-wallet/types/types-eoa/wallet';
 import { EBridge, TEBridgeOptions } from '@portkey-wallet/utils/eBridgeEOA';
 import { ICreateReceiptParams } from '@portkey-wallet/utils/eBridgeEOA/types/bridge';
-import CrossTransfer from '@portkey-wallet/utils/withdrawEOA';
-import { IWithdrawParams } from '@portkey-wallet/utils/withdrawEOA/types';
+// [DEPRECATED-ETRANSFER] BEGIN - ETransfer imports removed
+// import CrossTransfer from '@portkey-wallet/utils/withdrawEOA';
+// import { IWithdrawParams } from '@portkey-wallet/utils/withdrawEOA/types';
+// [DEPRECATED-ETRANSFER] END
 import SandboxEventTypes from 'messages/SandboxEventTypes';
 import SandboxEventService, { SandboxErrorCode } from 'service/SandboxEventService';
 
-export class CrossTransferExtension extends CrossTransfer {
-  constructor() {
-    super();
-  }
-
-  withdraw = async (params: Omit<IWithdrawParams, 'tokenContract' | 'portkeyContract'>) => {
-    const resMessage = await SandboxEventService.dispatchAndReceive(SandboxEventTypes.etransferCrossTransfer, {
-      chainType: 'aelf',
-      rpcUrl: '',
-      options: JSON.stringify(this.options),
-      params: JSON.stringify(params),
-    });
-
-    if (resMessage.code === SandboxErrorCode.error) throw resMessage.message;
-    return {
-      code: resMessage.code,
-      result: {
-        // rpcUrl,
-        message: resMessage.message,
-      },
-    } as any;
-  };
-}
+/**
+ * [DEPRECATED-ETRANSFER] - CrossTransferExtension class is deprecated.
+ * Use CrossEBridgeExtension for all cross-chain transfers instead.
+ */
+// export class CrossTransferExtension extends CrossTransfer {
+//   constructor() {
+//     super();
+//   }
+//
+//   withdraw = async (params: Omit<IWithdrawParams, 'tokenContract' | 'portkeyContract'>) => {
+//     const resMessage = await SandboxEventService.dispatchAndReceive(SandboxEventTypes.etransferCrossTransfer, {
+//       chainType: 'aelf',
+//       rpcUrl: '',
+//       options: JSON.stringify(this.options),
+//       params: JSON.stringify(params),
+//     });
+//
+//     if (resMessage.code === SandboxErrorCode.error) throw resMessage.message;
+//     return {
+//       code: resMessage.code,
+//       result: {
+//         // rpcUrl,
+//         message: resMessage.message,
+//       },
+//     } as any;
+//   };
+// }
 
 export class CrossEBridgeExtension extends EBridge {
   public pin: string;


### PR DESCRIPTION
- Comment out ETransfer logic in Send/index.tsx, use eBridge for aelf internal cross-chain
- Remove E_TRANSFER related conditions in SendPreview and utils
- Deprecate useCrossTransferByEtransfer and useCheckETransferIsRegistration hooks
- Comment out CrossTransferExtension class, keep CrossEBridgeExtension
- Remove etransferCrossTransfer from sandboxUtil and SandboxEventTypes
- Comment out ETransfer logic in ReceiveCardPage, Example, and MyBalance